### PR TITLE
Explicitly wait for port to be freed

### DIFF
--- a/src/main/java/com/github/lernejo/korekto/grader/api/parts/Part4Grader.java
+++ b/src/main/java/com/github/lernejo/korekto/grader/api/parts/Part4Grader.java
@@ -67,6 +67,8 @@ public class Part4Grader implements PartGrader {
             return result(List.of("Server (standalone) failed to start within " + LaunchingContext.SERVER_START_TIMEOUT + " sec."), 0.0D);
         } catch (IOException e) {
             return result(List.of("Fail to call server: " + e.getMessage()), 0.0D);
+        } finally {
+            PartGrader.waitForPortToBeFreed(context.standalonePlayerPort);
         }
     }
 

--- a/src/main/java/com/github/lernejo/korekto/grader/api/parts/Part5Grader.java
+++ b/src/main/java/com/github/lernejo/korekto/grader/api/parts/Part5Grader.java
@@ -68,6 +68,8 @@ public class Part5Grader implements PartGrader {
         } catch (IOException e) {
             context.httpServerFailed = true;
             return result(List.of("Fail to call server: " + e.getMessage()), 0.0D);
+        } finally {
+            PartGrader.waitForPortToBeFreed(context.standalonePlayerPort);
         }
     }
 }

--- a/src/main/java/com/github/lernejo/korekto/grader/api/parts/Part6Grader.java
+++ b/src/main/java/com/github/lernejo/korekto/grader/api/parts/Part6Grader.java
@@ -9,7 +9,6 @@ import com.github.lernejo.korekto.toolkit.misc.Ports;
 import com.github.lernejo.korekto.toolkit.thirdparty.git.GitContext;
 import com.github.lernejo.korekto.toolkit.thirdparty.maven.MavenExecutionHandle;
 import com.github.lernejo.korekto.toolkit.thirdparty.maven.MavenExecutor;
-import com.github.lernejo.korekto.toolkit.thirdparty.maven.MavenInvocationResult;
 import org.awaitility.core.ConditionTimeoutException;
 
 import java.util.ArrayList;
@@ -65,6 +64,8 @@ public class Part6Grader implements PartGrader {
                 } catch (ConditionTimeoutException e) {
                     return result(List.of("No request made to instance (@" + context.standaloneProxyPort + ") when passing a second parameter: `" + standaloneUrl + "`"), 0.0D);
                 }
+            } finally {
+                PartGrader.waitForPortToBeFreed(context.secondPlayerPort);
             }
         }
     }

--- a/src/main/java/com/github/lernejo/korekto/grader/api/parts/Part7Grader.java
+++ b/src/main/java/com/github/lernejo/korekto/grader/api/parts/Part7Grader.java
@@ -95,9 +95,13 @@ public class Part7Grader implements PartGrader {
                 }
             } catch (RuntimeException e) {
                 return result(List.of("Server (in client mode) failed to start within " + LaunchingContext.SERVER_START_TIMEOUT + " sec."), 0.0D);
+            } finally {
+                PartGrader.waitForPortToBeFreed(context.secondPlayerPort);
             }
         } catch (RuntimeException e) {
             return result(List.of("Server (standalone) failed to start within " + LaunchingContext.SERVER_START_TIMEOUT + " sec."), 0.0D);
+        } finally {
+            PartGrader.waitForPortToBeFreed(context.standalonePlayerPort);
         }
         return result(errors, grade);
     }

--- a/src/main/java/com/github/lernejo/korekto/grader/api/parts/PartGrader.java
+++ b/src/main/java/com/github/lernejo/korekto/grader/api/parts/PartGrader.java
@@ -8,7 +8,10 @@ import com.github.lernejo.korekto.toolkit.thirdparty.git.GitContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
+import java.net.Socket;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 public interface PartGrader {
 
@@ -28,5 +31,26 @@ public interface PartGrader {
 
     default GradePart result(List<String> explanations, double grade) {
         return new GradePart(name(), Math.min(Math.max(minGrade(), grade), maxGrade()), maxGrade(), explanations);
+    }
+
+    static void waitForPortToBeFreed(int port) {
+        do {
+            if (!isListened(port)) {
+                return;
+            }
+            try {
+                TimeUnit.MILLISECONDS.sleep(50L);
+            } catch (InterruptedException e) {
+                throw new IllegalStateException(e);
+            }
+        } while (true);
+    }
+
+    static boolean isListened(int port) {
+        try (Socket so = new Socket((String) null, port)) {
+            return true;
+        } catch (IOException ignored) {
+            return false;
+        }
     }
 }

--- a/src/test/java/com/github/lernejo/korekto/grader/api/JavaApiGraderTest.java
+++ b/src/test/java/com/github/lernejo/korekto/grader/api/JavaApiGraderTest.java
@@ -11,7 +11,6 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@Disabled("using external Maven commands does not seems to work in GitHub CI, to investigate")
 class JavaApiGraderTest {
 
     @BeforeEach


### PR DESCRIPTION
Curiously on Unix environment (tested on Ubuntu) a port can still be in
use even if the process which listened to it was interrupted.

Should fix #2 